### PR TITLE
Fix .env launch time loading

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -52,7 +52,7 @@ const Home = (props: HomeProps) => {
     severity: undefined,
   });
 
-  const [startDate, setStartDate] = useState(new Date(props.startDate));
+  const [startDate, setStartDate] = useState(new Date(props.startDate * 1000));
 
   const wallet = useAnchorWallet();
   const [candyMachine, setCandyMachine] = useState<CandyMachine>();


### PR DESCRIPTION
# Description

The initial go live date of the candy machine is loaded from the `.env` file. However, javascript's `Date` constructor expects to be given a value in `milliseconds`, not `seconds`, as is the convention for unix timestamps.
This bug may not have been observed, as the true go live date is loaded from the candy machine soon after page load.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?
* Set `REACT_APP_CANDY_START_DATE` to a unix timestamp in the future, such as `1640998800` (2022)
* Set candy machine backing it to have the same start date
* Observe on load the 'Mint' button will be available for a few seconds before state is fetched from the server. 
* Presumably this can be extended for testing by disabling internet connection
* After patch applied, Mint button should correctly show countdown right after page load
