### PR TITLE
Add support for custom SPL mints

### DIFF
--- a/src/candy-machine.ts
+++ b/src/candy-machine.ts
@@ -29,7 +29,8 @@ interface CandyMachineState {
   itemsAvailable: number;
   itemsRedeemed: number;
   itemsRemaining: number;
-  goLiveDate: Date,
+  goLiveDate: Date;
+  tokenMint?: anchor.web3.PublicKey;
 }
 
 export const awaitTransactionSignatureConfirmation = async (
@@ -176,6 +177,7 @@ export const getCandyMachineState = async (
   const itemsAvailable = state.data.itemsAvailable.toNumber();
   const itemsRedeemed = state.itemsRedeemed.toNumber();
   const itemsRemaining = itemsAvailable - itemsRedeemed;
+  const tokenMint = state.tokenMint;
 
   let goLiveDate = state.data.goLiveDate.toNumber();
   goLiveDate = new Date(goLiveDate * 1000);
@@ -186,6 +188,7 @@ export const getCandyMachineState = async (
     itemsRedeemed,
     itemsRemaining,
     goLiveDate,
+    tokenMint
   };
 }
 
@@ -237,6 +240,7 @@ export const mintOneToken = async (
   config: anchor.web3.PublicKey, // feels like this should be part of candyMachine?
   payer: anchor.web3.PublicKey,
   treasury: anchor.web3.PublicKey,
+  associatedTokenAccountAddress?: anchor.web3.PublicKey,
 ): Promise<string> => {
   const mint = anchor.web3.Keypair.generate();
   const token = await getTokenWallet(payer, mint.publicKey);
@@ -247,6 +251,13 @@ export const mintOneToken = async (
   const rent = await connection.getMinimumBalanceForRentExemption(
     MintLayout.span
   );
+
+  const remainingAccounts = [];
+  if (associatedTokenAccountAddress) {
+    console.log("here", associatedTokenAccountAddress);
+    remainingAccounts.push({ pubkey: associatedTokenAccountAddress, isWritable: true, isSigner: false });
+    remainingAccounts.push({ pubkey: payer, isWritable: false, isSigner: true });
+  }
 
   return await program.rpc.mintNft({
     accounts: {
@@ -266,6 +277,7 @@ export const mintOneToken = async (
       clock: anchor.web3.SYSVAR_CLOCK_PUBKEY,
     },
     signers: [mint],
+    remainingAccounts,
     instructions: [
       anchor.web3.SystemProgram.createAccount({
         fromPubkey: payer,


### PR DESCRIPTION
# Description

Following [this guide](https://docs.google.com/document/d/1ZJsbLJXKCAqUsOU6a0Jk-yOuSYi-uOMYdQZIILGsvxE/mobilebasic) that explains how to use Candy Machine with custom SPL tokens for Raydium Dropzone requires the frontend to support custom SPL tokens

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

## How Has This Been Tested?
Set `REACT_APP_TREASURY_ADDRESS` to the created account for the specified spl-token and that's all, it worked seamlessly
