### PR TITLE
[fix] Prevent balance from being fetched twice on startup

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -152,12 +152,12 @@ const Home = (props: HomeProps) => {
 
   useEffect(() => {
     (async () => {
-      if (wallet) {
+      if (wallet?.publicKey) {
         const balance = await props.connection.getBalance(wallet.publicKey);
         setBalance(balance / LAMPORTS_PER_SOL);
       }
     })();
-  }, [wallet, props.connection]);
+  }, [wallet?.publicKey, props.connection]);
 
   useEffect(refreshCandyMachineState, [
     wallet,


### PR DESCRIPTION
# Description

Right now, we fetch the wallet balance twice on startup.

This is because of the way we've configured the effect that fetches the wallet balance on startup. It re-runs whenever _anything_ in `wallet` changes, even though we only need the `publicKey` to be able to fetch the balance.

In this pull request, we modify the dependencies array so that the only thing that can cause this effect to re-run, is a change in the `publicKey`.

## Type of change

- [ ] Bug fix

## How Has This Been Tested?

Loaded the mint site locally, and noticed that now we only call the `getBalance` API once.