### PR TITLE
[enhancement] Speed up minting by parallelizing setup

### DIFF
--- a/src/candy-machine.ts
+++ b/src/candy-machine.ts
@@ -246,15 +246,15 @@ export const mintOneToken = async (
   payer: anchor.web3.PublicKey,
   treasury: anchor.web3.PublicKey,
 ): Promise<string> => {
-  const mint = anchor.web3.Keypair.generate();
-  const token = await getTokenWallet(payer, mint.publicKey);
   const { connection, program } = candyMachine;
-  const metadata = await getMetadata(mint.publicKey);
-  const masterEdition = await getMasterEdition(mint.publicKey);
 
-  const rent = await connection.getMinimumBalanceForRentExemption(
-    MintLayout.span
-  );
+  const mint = anchor.web3.Keypair.generate();
+  const [masterEdition, metadata, rent, token] = await Promise.all([
+    getMasterEdition(mint.publicKey),
+    getMetadata(mint.publicKey),
+    connection.getMinimumBalanceForRentExemption(MintLayout.span),
+    getTokenWallet(payer, mint.publicKey),
+  ]);
 
   return await program.rpc.mintNft({
     accounts: {


### PR DESCRIPTION
# Description

When the user clicks the mint button, we do four small async operations to set up the transaction. Despite the fact that none of these transactions depend on one another, we've written them to be executed in series.

```
const foo = await getFoo();
const bar = await getBar();
const baz = await getBaz();
const bat = await getBat();
```

Instead, what we can do is to generate all of the _promises_ at once, let the network IO start, and wait on the results as a group.

```
const [foo, bar, baz, bat] = await Promise.all([
  getFoo(),
  getBar(),
  getBaz(),
  getBat(),
]);
```

This isn't going to result in a _huge_ speedup, since most of the async work here is CPU bound and not network bound, but it's a good habit to get into none the less.

## Type of change

- [x] Enhancement

## How Has This Been Tested?

I loaded up the site locally and minted several tokens on devnet.